### PR TITLE
This should work

### DIFF
--- a/mtgsimulator.cabal
+++ b/mtgsimulator.cabal
@@ -19,5 +19,5 @@ library
   hs-source-dirs:      src
   exposed-modules:     MTGSimulator
   -- other-modules:       
-  build-depends:       base == 4.6.*
+  build-depends:       base       >=  4.3 && <5
                      , containers ==  0.5.5.1

--- a/src/MTGSimulator.hs
+++ b/src/MTGSimulator.hs
@@ -1,5 +1,11 @@
+{-# LANGUAGE DataKinds, FlexibleContexts, KindSignatures,
+             PolyKinds, TypeFamilies, TypeOperators, GADTs #-}
+
 module MTGSimulator where
 
+import Control.Applicative
+import Data.Type.Equality
+import Data.Proxy
 import qualified Data.Map.Strict as Map
 
 data Mana = Black | Blue | Green | Red | White | Colorless | Hybrid Mana Mana deriving (Show, Eq, Ord)
@@ -27,3 +33,43 @@ castableWith available cost = all hasAdequateManaFor $ Map.keys costCounts
         hasAdequateManaFor symbol = amountAvailable >= amountNeeded
           where amountAvailable = countBySymbol symbol availableCounts
                 amountNeeded    = countBySymbol symbol costCounts
+
+-- here begins the experimentation, note, this is a decidedly unfancy
+-- way to solve this problem. How I tend to roll. I can point you in
+-- the direction of fancy if you want it.
+
+manaMinimum :: Int
+manaMinimum = 0
+manaMax :: Int
+manaMax = 12
+
+-- you don't export the newtype value constructor (just the type constructor)
+-- so users can't bypass the validation. This'll be a nice demo of applicatives anyway.
+
+newtype ManaCost = ManaCost Int deriving (Eq, Show)
+mkManaCost :: Int -> Maybe ManaCost
+mkManaCost cost
+  | cost < manaMinimum = Nothing
+  | cost > manaMax     = Nothing
+  | otherwise = Just $ ManaCost cost
+
+-- mkManaCost (-1) -> Nothing
+-- mkManaCost 0    -> Nothing
+
+data CardManaCost = CardManaCost { blackManaCost      :: ManaCost
+                                 , blueManaCost       :: ManaCost
+                                 , greenManaCost      :: ManaCost
+                                 , redManaCost        :: ManaCost
+                                 , whiteManaCost      :: ManaCost
+                                 , colorlessManaCost  :: ManaCost } deriving (Eq, Show)
+
+-- example of how to work with datatype
+
+zeroCostCard :: Maybe CardManaCost
+zeroCostCard = CardManaCost <$>
+               mkManaCost 0 <*>
+               mkManaCost 0 <*>
+               mkManaCost 0 <*>
+               mkManaCost 0 <*>
+               mkManaCost 0 <*>
+               mkManaCost 0

--- a/src/MTGSimulator.hs
+++ b/src/MTGSimulator.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DataKinds, FlexibleContexts, KindSignatures,
-             PolyKinds, TypeFamilies, TypeOperators, GADTs #-}
-
 module MTGSimulator where
 
 import Control.Applicative


### PR DESCRIPTION
I dove into some magic but it starts getting into serious "I really want dependent types" craziness and that's an impulse you just have to resist the majority of time in Haskell.

The safer way to go would be to simply enumerate all the combinations of types with proxy types for the mana inhabitants or something similar.

The solution I've hammered out is designed to avoid necessitating that but still only allowing the computation of card mana cost values that are kosher.

Let me know if you want to discuss further.
